### PR TITLE
Verify Quick Status Select on Foundry V14 and polish search filtering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Remove the 'v' from the tag for versioning
     - id: get_version
@@ -33,7 +33,7 @@ jobs:
         allowUpdates: true # set this to false if you want to prevent updating existing releases
         name: ${{ github.event.release.name }}
         draft: false
-        prerelease: true
+        prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: './src/module.json, ./src/module.zip'
         tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Remove the 'v' from the tag for versioning
+    # Write release asset URLs using the actual published tag.
     - id: get_version
       run: |
         echo "FOUNDRY_MANIFEST=https://github.com/${{github.repository}}/releases/latest/download/module.json" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -4,19 +4,13 @@ Quick Status Select adds a search row to Foundry VTT's Token HUD status-effect p
 
 ## Install
 
-In Foundry, open **Add-on Modules > Install Module**, paste a manifest URL into **Manifest URL**, and install.
-
-Official upstream channel:
-
-```text
-https://github.com/jeremiahverba/qss/releases/latest/download/module.json
-```
-
-Spencer's Foundry V14 compatibility build:
+In Foundry, open **Add-on Modules > Install Module**, paste this into **Manifest URL**, and install Spencer's Foundry V14 compatibility build:
 
 ```text
 https://github.com/SpencerZPoole/qss/releases/latest/download/module.json
 ```
+
+The original upstream repository is <https://github.com/jeremiahverba/qss>. At this time, this compatibility build is the verified pasteable manifest channel for the V14 update.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,54 @@
 # Quick Status Select
-This is a fork of the origial projekt. I've rebuilt it to provide support to the following:
-- Foundry v12
-- Lancer RPG
-- Pathfinder 2e
-- Monk's Little Details
 
-It should work with any combination of the above. Most other systems and modules should work, as long as they don't change how the status hud is displayed. 
+Quick Status Select adds a search row to Foundry VTT's Token HUD status-effect palette, making it faster to find and apply conditions or effects on a selected token.
 
-### A Foundry VTT module that helps quickly select effects for a token or tokens by replacing the built-in status effect selector with an auto-complete-esque search box and filtered list.
+## Install
 
-### <img src="https://raw.githubusercontent.com/jeremiahverba/qss/main/qss-empty.png" alt="Image of Quick Status Select" width=400/>
+Use the latest release manifest in Foundry's module installer:
 
-### <img src="https://raw.githubusercontent.com/jeremiahverba/qss/main/qss-example1.png" alt="Image of Quick Status Select 2" width=400/>
+```text
+https://github.com/jeremiahverba/qss/releases/latest/download/module.json
+```
 
-### <img src="https://raw.githubusercontent.com/jeremiahverba/qss/main/qss-example2.png" alt="Image of Quick Status Select 3" width=400/>
+## Compatibility
 
-created with help from: [https://gitlab.com/foundry-projects/foundry-pc/create-foundry-project/-/wikis/home](https://gitlab.com/foundry-projects/foundry-pc/create-foundry-project/-/wikis/home)
+- Module version: `2.0.3`
+- Foundry VTT: minimum `13`, verified `14.362`
+- Verified test environment: Foundry `14.362` with D35E `3.0.2`
+
+Quick Status Select is intended to remain system-agnostic for systems and modules that preserve Foundry's standard Token HUD status-effect palette.
+
+## Usage
+
+1. Enable **Quick Status Select** in your world.
+2. Select a token and open the Token HUD.
+3. Open the status/effects palette.
+4. Type in the **Search:** field to filter statuses by id or localized label.
+5. Press Enter to apply the first visible matching status, or click any visible icon.
+
+## Changes in 2.0.3
+
+This release keeps the existing QSS experience and focuses on Foundry V14 compatibility and HUD polish:
+
+- Verified the module on Foundry VTT `14.362`.
+- Replaced regex filtering with plain-text matching, so special characters in the search field cannot trigger invalid-regex errors.
+- Restored a visible **Search:** row with a `Status` placeholder in the Token HUD status palette.
+- Kept the search row compact and part of the icon grid while filtering, preventing a large blank overlay area from appearing above filtered results.
+- Reset the palette scroll position as the filter changes, so matching icons stay anchored below the search row.
+- Kept Enter-to-apply and clickable status icons working with the filtered results.
+
+## Screenshots
+
+<img src="https://raw.githubusercontent.com/jeremiahverba/qss/main/qss-empty.png" alt="Quick Status Select with the status search field empty" width="400"/>
+
+<img src="https://raw.githubusercontent.com/jeremiahverba/qss/main/qss-example1.png" alt="Quick Status Select filtering status effects" width="400"/>
+
+<img src="https://raw.githubusercontent.com/jeremiahverba/qss/main/qss-example2.png" alt="Quick Status Select showing a narrowed status list" width="400"/>
+
+## Credits and License
+
+Quick Status Select was originally created by Jeremiah Verba. This release also includes compatibility work credited to Emmi in the module metadata and contributions from upstream maintainers.
+
+The module is distributed under the existing MIT license. See `src/LICENSE` for the license text and original copyright notice.
+
+Created with help from [create-foundry-project](https://gitlab.com/foundry-projects/foundry-pc/create-foundry-project/-/wikis/home).

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ Quick Status Select adds a search row to Foundry VTT's Token HUD status-effect p
 
 ## Install
 
-Use the latest release manifest in Foundry's module installer:
+In Foundry, open **Add-on Modules > Install Module**, paste a manifest URL into **Manifest URL**, and install.
+
+Official upstream channel:
 
 ```text
 https://github.com/jeremiahverba/qss/releases/latest/download/module.json
+```
+
+Spencer's Foundry V14 compatibility build:
+
+```text
+https://github.com/SpencerZPoole/qss/releases/latest/download/module.json
 ```
 
 ## Compatibility

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "foundry-quick-status-select-module",
-	"version": "3.1.8",
+	"version": "2.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "foundry-quick-status-select-module",
-			"version": "3.1.8",
+			"version": "2.0.3",
 			"hasInstallScript": true,
 			"devDependencies": {
 				"@foundryvtt/foundryvtt-cli": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "foundry-quick-status-select-module",
-	"version": "3.1.8",
+	"version": "2.0.3",
 	"description": "A Foundry VTT module that helps quickly select effects for a token or tokens by replacing the built-in status effect selector with an auto-complete-esque search box and filtered list.",
 	"scripts": {
         "generate:symlinks": "node scripts/symlink.mjs",
@@ -9,8 +9,8 @@
         "run:foundry": "npx --config ./fvttrc.yml",
 		"version": "node scripts/version.mjs"
 	},
-	"author": "",
-	"license": "",
+	"author": "Jeremiah Verba and contributors",
+	"license": "MIT",
 	"devDependencies": {
 		"@foundryvtt/foundryvtt-cli": "^1.1.0"
 	}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2,7 +2,8 @@
   "quick-status-select": {
     "TokenHud": {
       "quick-input": {
-        "placeholder": "Filter"
+        "label": "Search:",
+        "placeholder": "Status"
       }
     }
   }

--- a/src/module.json
+++ b/src/module.json
@@ -10,10 +10,10 @@
       "name": "Emmi"
     }
   ],
-  "version": "2.0.0",
+  "version": "2.0.3",
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "14.362"
   },
   "esmodules": [
     "scripts/qss.mjs"
@@ -23,7 +23,7 @@
   ],
   "languages": [{ "lang": "en", "name": "English", "path": "lang/en.json" }],
   "license": "LICENSE",
-  "url": "https://github.com/tw-blob/qss",
-  "manifest": "https://github.com/tw-blob/qss/releases/latest/download/module.json",
-  "download": "https://github.com/tw-blob/qss/releases/download/2.0.0/module.zip"
+  "url": "https://github.com/jeremiahverba/qss",
+  "manifest": "https://github.com/jeremiahverba/qss/releases/latest/download/module.json",
+  "download": "https://github.com/jeremiahverba/qss/releases/download/v2.0.3/module.zip"
 }

--- a/src/module.json
+++ b/src/module.json
@@ -25,5 +25,5 @@
   "license": "LICENSE",
   "url": "https://github.com/jeremiahverba/qss",
   "manifest": "https://github.com/jeremiahverba/qss/releases/latest/download/module.json",
-  "download": "https://github.com/jeremiahverba/qss/releases/download/v2.0.3/module.zip"
+  "download": "https://github.com/jeremiahverba/qss/releases/latest/download/module.zip"
 }

--- a/src/scripts/qss.mjs
+++ b/src/scripts/qss.mjs
@@ -1,32 +1,44 @@
 Hooks.on('renderTokenHUD', /** @param {HTMLFormElement} html */(_app, html) => {
   /** @type {HTMLDivElement} */
   const statusEffects = html.querySelector(".col.right .palette.status-effects");
+  if (!statusEffects || statusEffects.querySelector(".qss-quick-filter")) return;
+  statusEffects.classList.add("qss-status-effects");
 
-  const qssQuickInput = document.createElement('input')
-  qssQuickInput.type = "text";
+  const qssQuickFilter = document.createElement('label');
+  qssQuickFilter.classList.add("qss-quick-filter");
+
+  const qssQuickLabel = document.createElement('span');
+  qssQuickLabel.classList.add("qss-quick-label");
+  qssQuickLabel.textContent = game.i18n.localize("quick-status-select.TokenHud.quick-input.label");
+
+  const qssQuickInput = document.createElement('input');
+  qssQuickInput.type = "search";
   qssQuickInput.placeholder = game.i18n.localize("quick-status-select.TokenHud.quick-input.placeholder");
   qssQuickInput.classList.add("qss-quick-input");
-  statusEffects.prepend(qssQuickInput);
+  qssQuickFilter.append(qssQuickLabel, qssQuickInput);
+  statusEffects.prepend(qssQuickFilter);
 
   qssQuickInput.addEventListener('input', () => {
     const term = qssQuickInput.value.trim().toLowerCase();
     /** @type {NodeListOf<HTMLElement>} */
     const effects = statusEffects.querySelectorAll('.effect-control');
     for (const e of effects) {
-      const id = e.dataset.statusId?.trim().toLowerCase();
-      const label = (e.dataset.tooltipText || game.i18n.localize(e.dataset.tooltip))?.trim().toLowerCase();
-      e.hidden = !(id.match(term) || label.match(term))
+      const id = e.dataset.statusId?.trim().toLowerCase() ?? "";
+      const label = (e.dataset.tooltipText || game.i18n.localize(e.dataset.tooltip ?? ""))?.trim().toLowerCase() ?? "";
+      e.hidden = !(id.includes(term) || label.includes(term));
     }
+    statusEffects.scrollTop = 0;
   });
 
-  qssQuickInput.addEventListener('keypress', e => {
-    debug('got keypress:', e.key, game.qssSearchTerm);
-    if (e.key === 'Enter' && qssQuickInput.value.trim()) {
+  qssQuickInput.addEventListener('keydown', event => {
+    debug('got keydown:', event.key, game.qssSearchTerm);
+    if (event.key === 'Enter' && qssQuickInput.value.trim()) {
+      event.preventDefault();
       /** @type {NodeListOf<HTMLElement>} */
       const effects = statusEffects.querySelectorAll('.effect-control');
-      for (const e of effects) {
-        if (!e.hidden) {
-          e.click();
+      for (const effect of effects) {
+        if (!effect.hidden) {
+          effect.click();
           break;
         }
       }
@@ -35,7 +47,7 @@ Hooks.on('renderTokenHUD', /** @param {HTMLFormElement} html */(_app, html) => {
 
   html
     .querySelector("button[data-palette='effects']")
-    .addEventListener('mouseup', () => setTimeout(() => qssQuickInput.focus(), 0));
+    ?.addEventListener('mouseup', () => setTimeout(() => qssQuickInput.focus(), 0));
 });
 
 // Debug logging helper

--- a/src/scripts/qss.mjs
+++ b/src/scripts/qss.mjs
@@ -1,53 +1,64 @@
 Hooks.on('renderTokenHUD', /** @param {HTMLFormElement} html */(_app, html) => {
   /** @type {HTMLDivElement} */
   const statusEffects = html.querySelector(".col.right .palette.status-effects");
-  if (!statusEffects || statusEffects.querySelector(".qss-quick-filter")) return;
+  if (!statusEffects) return;
   statusEffects.classList.add("qss-status-effects");
 
-  const qssQuickFilter = document.createElement('label');
-  qssQuickFilter.classList.add("qss-quick-filter");
+  /** @type {HTMLInputElement | null} */
+  let qssQuickInput = statusEffects.querySelector(".qss-quick-input");
+  if (!qssQuickInput) {
+    const qssQuickFilter = document.createElement('label');
+    qssQuickFilter.classList.add("qss-quick-filter");
 
-  const qssQuickLabel = document.createElement('span');
-  qssQuickLabel.classList.add("qss-quick-label");
-  qssQuickLabel.textContent = game.i18n.localize("quick-status-select.TokenHud.quick-input.label");
+    const qssQuickLabel = document.createElement('span');
+    qssQuickLabel.classList.add("qss-quick-label");
+    qssQuickLabel.textContent = game.i18n.localize("quick-status-select.TokenHud.quick-input.label");
 
-  const qssQuickInput = document.createElement('input');
-  qssQuickInput.type = "search";
-  qssQuickInput.placeholder = game.i18n.localize("quick-status-select.TokenHud.quick-input.placeholder");
-  qssQuickInput.classList.add("qss-quick-input");
-  qssQuickFilter.append(qssQuickLabel, qssQuickInput);
-  statusEffects.prepend(qssQuickFilter);
+    qssQuickInput = document.createElement('input');
+    qssQuickInput.type = "search";
+    qssQuickInput.placeholder = game.i18n.localize("quick-status-select.TokenHud.quick-input.placeholder");
+    qssQuickInput.classList.add("qss-quick-input");
+    qssQuickFilter.append(qssQuickLabel, qssQuickInput);
+    statusEffects.prepend(qssQuickFilter);
+  }
 
-  qssQuickInput.addEventListener('input', () => {
-    const term = qssQuickInput.value.trim().toLowerCase();
-    /** @type {NodeListOf<HTMLElement>} */
-    const effects = statusEffects.querySelectorAll('.effect-control');
-    for (const e of effects) {
-      const id = e.dataset.statusId?.trim().toLowerCase() ?? "";
-      const label = (e.dataset.tooltipText || game.i18n.localize(e.dataset.tooltip ?? ""))?.trim().toLowerCase() ?? "";
-      e.hidden = !(id.includes(term) || label.includes(term));
-    }
-    statusEffects.scrollTop = 0;
-  });
+  if (!qssQuickInput.dataset.qssListenersBound) {
+    qssQuickInput.dataset.qssListenersBound = "true";
 
-  qssQuickInput.addEventListener('keydown', event => {
-    debug('got keydown:', event.key, game.qssSearchTerm);
-    if (event.key === 'Enter' && qssQuickInput.value.trim()) {
-      event.preventDefault();
+    qssQuickInput.addEventListener('input', () => {
+      const term = qssQuickInput.value.trim().toLowerCase();
       /** @type {NodeListOf<HTMLElement>} */
       const effects = statusEffects.querySelectorAll('.effect-control');
       for (const effect of effects) {
-        if (!effect.hidden) {
-          effect.click();
-          break;
+        const id = effect.dataset.statusId?.trim().toLowerCase() ?? "";
+        const labelSource = effect.dataset.tooltipText || (effect.dataset.tooltip ? game.i18n.localize(effect.dataset.tooltip) : "");
+        const label = labelSource.trim().toLowerCase();
+        effect.hidden = !(id.includes(term) || label.includes(term));
+      }
+      statusEffects.scrollTop = 0;
+    });
+
+    qssQuickInput.addEventListener('keydown', event => {
+      debug('got keydown:', event.key, qssQuickInput.value);
+      if (event.key === 'Enter' && qssQuickInput.value.trim()) {
+        event.preventDefault();
+        /** @type {NodeListOf<HTMLElement>} */
+        const effects = statusEffects.querySelectorAll('.effect-control');
+        for (const effect of effects) {
+          if (!effect.hidden) {
+            effect.click();
+            break;
+          }
         }
       }
-    }
-  });
+    });
+  }
 
-  html
-    .querySelector("button[data-palette='effects']")
-    ?.addEventListener('mouseup', () => setTimeout(() => qssQuickInput.focus(), 0));
+  const effectsButton = html.querySelector("button[data-palette='effects']");
+  if (effectsButton && !effectsButton.dataset.qssFocusBound) {
+    effectsButton.dataset.qssFocusBound = "true";
+    effectsButton.addEventListener('click', () => setTimeout(() => qssQuickInput.focus(), 0));
+  }
 });
 
 // Debug logging helper

--- a/src/styles/qss.css
+++ b/src/styles/qss.css
@@ -1,5 +1,40 @@
-.qss-quick-input {
-  position: absolute;
-  top: -2.5rem;
-  left: 0rem;
+#token-hud .status-effects.qss-status-effects {
+  align-content: start;
+}
+
+#token-hud .status-effects .qss-quick-filter {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 28px;
+  padding: 3px;
+  background: var(--control-bg-color);
+  border-bottom: 1px solid var(--control-border-color);
+}
+
+#token-hud .status-effects .qss-quick-label {
+  flex: 0 0 auto;
+  color: var(--control-icon-color);
+  font-size: var(--font-size-12);
+  font-weight: 600;
+  line-height: 1;
+}
+
+#token-hud .status-effects .qss-quick-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 22px;
+  padding: 1px 5px;
+  background: var(--input-background-color, var(--color-cool-5-90));
+  border: 1px solid var(--control-border-color);
+  border-radius: 3px;
+  color: var(--control-icon-color);
+  font-size: var(--font-size-12);
+  line-height: 20px;
+}
+
+#token-hud .status-effects .qss-quick-input::placeholder {
+  color: var(--control-icon-color);
+  opacity: 0.7;
 }


### PR DESCRIPTION
## Summary

This updates Quick Status Select for a verified Foundry V14.362 workflow while preserving the existing Token HUD behavior.

- Updates compatibility metadata to module `2.0.3`, minimum Foundry `13`, verified Foundry `14.362`.
- Replaces regex-based filtering with plain-text matching so special characters in the search field cannot throw invalid-regex errors.
- Restores a visible `Search:` row with a `Status` placeholder in the Token HUD status palette.
- Keeps the search row compact and part of the status icon grid while filtering, including a scroll reset so filtered results stay anchored below the search row.
- Keeps Enter-to-apply and clickable visible status icons working.
- Refreshes README/install docs with upstream-owned URLs and credits for the original module and prior compatibility work.

## Validation

- `node --check src/scripts/qss.mjs`
- Manifest reference validation for scripts, styles, language file, license, and upstream release URLs
- README validation for Foundry `14.362`, D35E `3.0.2`, regex/plain-text stability note, visible/compact search-row note, and attribution
- Local changed-file security scan: 0 errors, 0 warnings
- Public fork release validation: `v2.0.3` manifest and zip are fetchable and the zip contains `module.json`, `scripts/qss.mjs`, `styles/qss.css`, `lang/en.json`, and `LICENSE`
- Live Foundry testing was performed against Foundry `14.362` with D35E `3.0.2`: status HUD opens, the search field is visible, typing filters statuses such as `pro` to prone-style matches without creating a large blank overlay area, filtered icons remain clickable, and Enter applies the first visible match.

Supporting validation release from my fork, if useful for comparison: https://github.com/SpencerZPoole/qss/releases/tag/v2.0.3